### PR TITLE
Change structopts to lower case and update usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TaskFly follows a three-tiered architecture:
 Adding a task is as simple as this:
 
 ```bash
-$ taskfly add "Blast Off 🚀" "/path/to/your/script.sh"
+$ taskfly add 🚀 "/path/to/your/script.sh"
 ```
 
 And you can list your tasks with:
@@ -50,7 +50,7 @@ $ taskfly remove "Your task description here"
 
 Want to change the urgency of a task? Here you go:
 ```bash
-$ taskfly edit "Your task description here" "Turtle Pace 🐢"
+$ taskfly edit "Your task description here" 🐢
 ```
 
 And, of course, you can always ask TaskFly for help:

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,21 +107,21 @@ impl TaskManager {
 #[derive(StructOpt, Debug)]
 #[structopt(name = "taskfly")]
 pub enum TaskFly {
-    #[structopt(name = "Add")]
+    #[structopt(name = "add")]
     Add {
         #[structopt(name = "UrgencyLevel")]
         level: UrgencyLevel,
         #[structopt(name = "Command")]
         command: String,
     },
-    #[structopt(name = "List")]
+    #[structopt(name = "list")]
     List,
     #[structopt(name = "Remove")]
     Remove {
         #[structopt(name = "Command")]
         command: String,
     },
-    #[structopt(name = "Edit")]
+    #[structopt(name = "edit")]
     Edit {
         #[structopt(name = "Command")]
         command: String,


### PR DESCRIPTION
This makes CLI usage in subcommands lowercase as usually expected.

Also fixed usage in README - urgency levels are only accepted as emoji, with no accompanying text.

Awesome project @zohar-yzgiaev ! :rocket: 